### PR TITLE
fix Dependencies.toJson

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -125,7 +125,7 @@ class Dependencies {
   }
 
   Map<String, dynamic> toJson() {
-    var json = {};
+    var json = Map<String, dynamic>();
 
     json.addAll(simpleDependencies);
 


### PR DESCRIPTION
this PR fix following error:

```
Unhandled exception:
type '_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>'
#0      Dependencies.toJson (package:pub_client/src/models.dart:144:5)
```